### PR TITLE
Added implementation for download the amqstreams tarball from RH CSP

### DIFF
--- a/roles/kafka_install/defaults/main.yaml
+++ b/roles/kafka_install/defaults/main.yaml
@@ -10,6 +10,8 @@ kafka_user: kafka
 kafka_group: kafka
 
 kafka_version: "{{ kafka_versions.keys() | first }}"
+
+amqstreams_version: "{{ amqstreams_versions.keys() | first }}"
 amqstreams_enable: false
 
 kafka_install_workdir: /opt/kafka

--- a/roles/kafka_install/defaults/main.yaml
+++ b/roles/kafka_install/defaults/main.yaml
@@ -12,9 +12,23 @@ kafka_group: kafka
 kafka_version: 3.1.1
 kafka_scala_version: 2.13
 
+kafka_rhn_id: 104335
+
 kafka_install_workdir: /opt/kafka
 kafka_home: "{{ kafka_install_workdir }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
 
-kafka_install_download_base_url: https://archive.apache.org/dist/kafka/{{ kafka_version }}
-kafka_install_archive_file: kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz
+kafka_install_download_base_url: >-
+  {{ 
+    ('https://archive.apache.org/dist/kafka/' + kafka_version | string) 
+    if (kafka_amqstreams_version is not defined) 
+    else ('https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=' + kafka_rhn_id | string) 
+  }}
+
+kafka_install_archive_file: >-
+  {{ 
+    ('kafka_' + kafka_scala_version | string + '-' + kafka_version | string + '.tgz') 
+    if (kafka_amqstreams_version is not defined) 
+    else ('amq-streams-' + kafka_amqstreams_version | string + '.zip') 
+  }}
+
 kafka_install_download_url: "{{ kafka_install_download_base_url }}/{{ kafka_install_archive_file }}"

--- a/roles/kafka_install/defaults/main.yaml
+++ b/roles/kafka_install/defaults/main.yaml
@@ -9,26 +9,9 @@ kafka_prereqs_packages:
 kafka_user: kafka
 kafka_group: kafka
 
-kafka_version: 3.1.1
-kafka_scala_version: 2.13
-
-kafka_rhn_id: 104335
+kafka_version: "{{ kafka_versions.keys() | first }}"
+amqstreams_enable: false
 
 kafka_install_workdir: /opt/kafka
-kafka_home: "{{ kafka_install_workdir }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}"
 
-kafka_install_download_base_url: >-
-  {{ 
-    ('https://archive.apache.org/dist/kafka/' + kafka_version | string) 
-    if (kafka_amqstreams_version is not defined) 
-    else ('https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=' + kafka_rhn_id | string) 
-  }}
-
-kafka_install_archive_file: >-
-  {{ 
-    ('kafka_' + kafka_scala_version | string + '-' + kafka_version | string + '.tgz') 
-    if (kafka_amqstreams_version is not defined) 
-    else ('amq-streams-' + kafka_amqstreams_version | string + '.zip') 
-  }}
-
-kafka_install_download_url: "{{ kafka_install_download_base_url }}/{{ kafka_install_archive_file }}"
+kafka_home: "{{ kafka_install_workdir }}/{{ amqstreams_enable | ternary(amqstreams_dirname, kafka_dirname) }}"

--- a/roles/kafka_install/tasks/install.yml
+++ b/roles/kafka_install/tasks/install.yml
@@ -1,10 +1,23 @@
 ---
-- name: "Check selected kafka version: {{ kafka_version }}"
-  ansible.builtin.assert:
-    that:
-      - kafka_versions[kafka_version] is defined
-    quiet: true
-    fail_msg: "Kafka version {{ kafka_version }} not defined, the allowed versions are: {{ kafka_versions.keys() }}"
+- name: Check install version
+  block:
+    - name: "Check selected kafka version: {{ kafka_version }}"
+      ansible.builtin.assert:
+        that:
+          - kafka_versions[kafka_version] is defined
+        quiet: true
+        fail_msg: "Kafka version {{ kafka_version }} not defined, the allowed versions are: {{ kafka_versions.keys() }}"
+      when:
+        - not amqstreams_enable
+
+    - name: "Check selected AMQ streams version: {{ amqstreams_version }}"
+      ansible.builtin.assert:
+        that:
+          - amqstreams_versions[amqstreams_version] is defined
+        quiet: true
+        fail_msg: "AMQ streams version {{ amqstreams_version }} not defined, the allowed versions are: {{ amqstreams_versions.keys() }}"
+      when:
+        - amqstreams_enable
   run_once: true
 
 - name: Check local download archive path
@@ -81,6 +94,8 @@
     dest: "{{ kafka_install_workdir }}"
     remote_src: true
     creates: "{{ kafka_home }}"
+    owner:  "{{ kafka_user }}"
+    group:  "{{ kafka_group }}"
   become: true
 
 - name: Check kafka home
@@ -105,11 +120,25 @@
   changed_when: false
   become: true
 
-- name: "Check kafka version is: {{ kafka_version }}"
-  ansible.builtin.assert:
-    that:
-      - __kafka_microversion is defined
-      - __kafka_microversion is defined
-    quiet: true
-    fail_msg: Kafka version is not as expected {{ __kafka_microversion }}.
-  become: true
+- name: Check Kafka microversion
+  when:
+    - __kafka_microversion is defined
+    - __kafka_microversion.stdout is defined
+  block:
+    - name: "Kafka version is: {{ kafka_version }}"
+      ansible.builtin.assert:
+        that:
+          - __kafka_microversion.stdout == kafka_versions[kafka_version]['microversion']
+        quiet: true
+        fail_msg: Kafka version is not as expected {{ __kafka_microversion }}.
+      when:
+        - not amqstreams_enable
+
+    - name: "AMQ streams version is: {{ amqstreams_version }}"
+      ansible.builtin.assert:
+        that:
+          - __kafka_microversion.stdout == amqstreams_versions[amqstreams_version]['microversion']
+        quiet: true
+        fail_msg: AMQ streams version is not as expected {{ __kafka_microversion }}.
+      when:
+        - amqstreams_enable

--- a/roles/kafka_install/tasks/install.yml
+++ b/roles/kafka_install/tasks/install.yml
@@ -10,6 +10,10 @@
     __kafka_remote_archive_path: "{{ kafka_install_workdir }}/{{ kafka_install_archive_file }}"
     __kafka_local_archive_path: "{{ __kafka_local_path.stat.path }}/{{ kafka_install_archive_file }}"
 
+- name: Set amqstreams enable
+  ansible.builtin.set_fact:
+    __kafka_amqstreams_enable: "{{ kafka_amqstreams_version is defined }}"
+
 - name: Check local archive
   ansible.builtin.stat:
     path: "{{ __kafka_local_archive_path }}"
@@ -24,14 +28,12 @@
     - name: Download from rhn
       ansible.builtin.include_tasks: install/rhn.yml
       when:
-        - __kafka_amqstreams_enable is defined
         - __kafka_amqstreams_enable
-        - __kafka_rhn_id is defined
 
     - name: Download from web
       ansible.builtin.include_tasks: install/web.yml
       when:
-        - __kafka_rhn_id is not defined
+        - not __kafka_amqstreams_enable
 
 - name: Check remote archive
   ansible.builtin.stat:

--- a/roles/kafka_install/tasks/install.yml
+++ b/roles/kafka_install/tasks/install.yml
@@ -1,18 +1,30 @@
 ---
+- name: "Check selected kafka version: {{ kafka_version }}"
+  ansible.builtin.assert:
+    that:
+      - kafka_versions[kafka_version] is defined
+    quiet: true
+    fail_msg: "Kafka version {{ kafka_version }} not defined, the allowed versions are: {{ kafka_versions.keys() }}"
+  run_once: true
+
 - name: Check local download archive path
   ansible.builtin.stat:
     path: "{{ lookup('env', 'PWD') }}"
   register: __kafka_local_path
   delegate_to: localhost
 
+- name: Set download filename
+  ansible.builtin.set_fact:
+    __kafka_install_archive_file: "{{ amqstreams_enable | ternary(amqstreams_archive_filename, kafka_archive_filename) }}"
+
 - name: Set download paths
   ansible.builtin.set_fact:
-    __kafka_remote_archive_path: "{{ kafka_install_workdir }}/{{ kafka_install_archive_file }}"
-    __kafka_local_archive_path: "{{ __kafka_local_path.stat.path }}/{{ kafka_install_archive_file }}"
+    __kafka_remote_archive_path: "{{ kafka_install_workdir }}/{{ __kafka_install_archive_file }}"
+    __kafka_local_archive_path: "{{ __kafka_local_path.stat.path }}/{{ __kafka_install_archive_file }}"
 
-- name: Set amqstreams enable
+- name: Set download url
   ansible.builtin.set_fact:
-    __kafka_amqstreams_enable: "{{ kafka_amqstreams_version is defined }}"
+    __kafka_install_download_url: "{{ amqstreams_enable | ternary(amqstreams_download_url, kafka_download_url) }}"
 
 - name: Check local archive
   ansible.builtin.stat:
@@ -28,12 +40,12 @@
     - name: Download from rhn
       ansible.builtin.include_tasks: install/rhn.yml
       when:
-        - __kafka_amqstreams_enable
+        - amqstreams_enable
 
     - name: Download from web
       ansible.builtin.include_tasks: install/web.yml
       when:
-        - not __kafka_amqstreams_enable
+        - not amqstreams_enable
 
 - name: Check remote archive
   ansible.builtin.stat:

--- a/roles/kafka_install/tasks/install/rhn.yml
+++ b/roles/kafka_install/tasks/install/rhn.yml
@@ -1,12 +1,14 @@
 ---
 # Red Hat Accounts fail due to SSO change: https://github.com/ansible-middleware/redhat-csp-download/issues/20
-- name: Download from Red Hat Customer Portal
+- name: Download AMQ streams from {{ __kafka_install_download_url }}
   collections:
   - middleware_automation.redhat_csp_download
   redhat_csp_download:
     dest: "{{ __kafka_local_archive_path }}"
-    url: "{{ kafka_install_download_base_url }}"
+    url: "{{ __kafka_install_download_url }}"
     username: "{{ lookup('env', 'RHN_USERNAME', default = kafka_install_url_username) }}"
     password: "{{ lookup('env', 'RHN_PASSWORD', default = kafka_install_url_password) }}"
-  delegate_to: localhost
   run_once: true
+  delegate_to: localhost
+  become: false
+  check_mode: false

--- a/roles/kafka_install/tasks/install/rhn.yml
+++ b/roles/kafka_install/tasks/install/rhn.yml
@@ -1,4 +1,12 @@
 ---
-- name: Show error
-  ansible.builtin.fail:
-    msg: Not implemented.
+# Red Hat Accounts fail due to SSO change: https://github.com/ansible-middleware/redhat-csp-download/issues/20
+- name: Download from Red Hat Customer Portal
+  collections:
+  - middleware_automation.redhat_csp_download
+  redhat_csp_download:
+    dest: "{{ __kafka_local_archive_path }}"
+    url: "{{ kafka_install_download_base_url }}"
+    username: "{{ lookup('env', 'RHN_USERNAME', default = kafka_install_url_username) }}"
+    password: "{{ lookup('env', 'RHN_PASSWORD', default = kafka_install_url_password) }}"
+  delegate_to: localhost
+  run_once: true

--- a/roles/kafka_install/tasks/install/web.yml
+++ b/roles/kafka_install/tasks/install/web.yml
@@ -1,7 +1,7 @@
 ---
-- name: Download Kafka from {{ kafka_install_download_url }}
+- name: Download Kafka from {{ __kafka_install_download_url }}
   ansible.builtin.get_url:
-    url: "{{ kafka_install_download_url }}"
+    url: "{{ __kafka_install_download_url }}"
     dest: "{{ __kafka_local_archive_path }}"
     url_username: "{{ kafka_install_url_username | default(omit) }}"
     url_password: "{{ kafka_install_url_password | default(omit) }}"

--- a/roles/kafka_install/vars/main.yaml
+++ b/roles/kafka_install/vars/main.yaml
@@ -1,48 +1,49 @@
 ---
-kafka_scala_version: "{{ kafka_versions[kafka_version]['scala_version'] }}"
-
+---
 # upstream
+kafka_scala_version: "{{ kafka_versions[kafka_version]['scala_version'] }}"
 kafka_archive_filename: "kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
 kafka_download_base_url: "https://archive.apache.org/dist/kafka"
 kafka_download_url: "{{ kafka_download_base_url }}/{{ kafka_version }}/{{ kafka_archive_filename }}"
-kafka_dirname: "kafka_{{ kafka_scala_version }}-{{ kafka_versions[kafka_version]['upstream']['version'] | regex_replace(' \\((.*)\\)$', '') }}"
+kafka_dirname: "kafka_{{ kafka_scala_version }}-{{ kafka_versions[kafka_version]['microversion'] | regex_replace(' \\((.*)\\)$', '') }}"
 
 # amqstreams
-amqstreams_archive_filename: "amq-streams-{{ kafka_versions[kafka_version]['amqstreams']['product_version'] }}-bin.zip"
+amqstreams_scala_version: "{{ amqstreams_versions[amqstreams_version]['scala_version'] }}"
+amqstreams_archive_filename: "amq-streams-{{ amqstreams_version }}-bin.zip"
 amqstreams_download_base_url: "https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html"
-amqstreams_download_url: "{{ amqstreams_download_base_url }}?softwareId={{ kafka_versions[kafka_version]['amqstreams']['rhn_id'] }}"
-amqstreams_dirname: "kafka_{{ kafka_scala_version }}-{{ kafka_versions[kafka_version]['amqstreams']['version'] | regex_replace(' \\((.*)\\)$', '') }}"
+amqstreams_download_url: "{{ amqstreams_download_base_url }}?softwareId={{ amqstreams_versions[amqstreams_version]['rhn_id'] }}"
+amqstreams_dirname: "kafka_{{ amqstreams_scala_version }}-{{ amqstreams_versions[amqstreams_version]['microversion'] | regex_replace(' \\((.*)\\)$', '') }}"
 
+# upstream catalogue
 kafka_versions:
   3.2.3:
     scala_version: 2.13
-    upstream:
-      version: 3.2.3 (Commit:50029d3ed8ba576f)
-    amqstreams:
-      version: 3.2.3.redhat-00003 (Commit:8c8f89d8e34196ab)
-      product_version: 2.2.0
-      rhn_id: 104745
+    microversion: 3.2.3 (Commit:50029d3ed8ba576f)
   3.1.0:
     scala_version: 2.13
-    upstream:
-      version: 3.1.0 (Commit:37edeed0777bacb3)
-    amqstreams:
-      version: 3.1.0.redhat-00004 (Commit:4c168d2882c7f93d)
-      product_version: 2.1.0
-      rhn_id: 104335
+    microversion: 3.1.0 (Commit:37edeed0777bacb3)
   3.0.0:
     scala_version: 2.13
-    upstream:
-      version: 3.0.0 (Commit:8cb0a5e9d3441962)
-    amqstreams:
-      version: 3.0.0.redhat-00008 (Commit:a92f6b92b6cb42fe)
-      product_version: 2.0.1
-      rhn_id: 104108
+    microversion: 3.0.0 (Commit:8cb0a5e9d3441962)
   2.8.0:
     scala_version: 2.12
-    upstream:
-      version: 2.8.0 (Commit:ebb1d6e21cc92130)
-    amqstreams:
-      version: 2.8.0.redhat-00004 (Commit:e4403b1af4b1e4d5)
-      product_version: 1.8.4
-      rhn_id: 103708
+    microversion: 2.8.0 (Commit:ebb1d6e21cc92130)
+
+# amqstreams catalogue
+amqstreams_versions:
+  2.2.0:
+    scala_version: 2.13
+    microversion: 3.2.3.redhat-00003 (Commit:8c8f89d8e34196ab)
+    rhn_id: 104745
+  2.1.0:
+    scala_version: 2.13
+    microversion: 3.1.0.redhat-00004 (Commit:4c168d2882c7f93d)
+    rhn_id: 104335
+  2.0.1:
+    scala_version: 2.13
+    microversion: 3.0.0.redhat-00008 (Commit:a92f6b92b6cb42fe)
+    rhn_id: 104108
+  1.8.4:
+    scala_version: 2.12
+    microversion: 2.8.0.redhat-00004 (Commit:e4403b1af4b1e4d5)
+    rhn_id: 103708

--- a/roles/kafka_install/vars/main.yaml
+++ b/roles/kafka_install/vars/main.yaml
@@ -1,15 +1,48 @@
 ---
-amqstreams_enable: false
+kafka_scala_version: "{{ kafka_versions[kafka_version]['scala_version'] }}"
 
-amqstreams_versions:
-  1.2.0:
-    dirname: kafka_2.12-2.2.1.redhat-00002
-    version: 2.2.1.redhat-00002 (Commit:c330425647372ca2)
+# upstream
+kafka_archive_filename: "kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
+kafka_download_base_url: "https://archive.apache.org/dist/kafka"
+kafka_download_url: "{{ kafka_download_base_url }}/{{ kafka_version }}/{{ kafka_archive_filename }}"
+kafka_dirname: "kafka_{{ kafka_scala_version }}-{{ kafka_versions[kafka_version]['upstream']['version'] | regex_replace(' \\((.*)\\)$', '') }}"
 
-  2.0.1:
-    dirname: kafka_2.13-3.0.0.redhat-00008
-    version: 3.0.0.redhat-00008 (Commit:a92f6b92b6cb42fe)
+# amqstreams
+amqstreams_archive_filename: "amq-streams-{{ kafka_versions[kafka_version]['amqstreams']['product_version'] }}-bin.zip"
+amqstreams_download_base_url: "https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html"
+amqstreams_download_url: "{{ amqstreams_download_base_url }}?softwareId={{ kafka_versions[kafka_version]['amqstreams']['rhn_id'] }}"
+amqstreams_dirname: "kafka_{{ kafka_scala_version }}-{{ kafka_versions[kafka_version]['amqstreams']['version'] | regex_replace(' \\((.*)\\)$', '') }}"
 
-  2.1.0:
-    dirname: kafka_2.13-3.1.0.redhat-00004
-    version: 3.1.0.redhat-00004 (Commit:4c168d2882c7f93d)
+kafka_versions:
+  3.2.3:
+    scala_version: 2.13
+    upstream:
+      version: 3.2.3 (Commit:50029d3ed8ba576f)
+    amqstreams:
+      version: 3.2.3.redhat-00003 (Commit:8c8f89d8e34196ab)
+      product_version: 2.2.0
+      rhn_id: 104745
+  3.1.0:
+    scala_version: 2.13
+    upstream:
+      version: 3.1.0 (Commit:37edeed0777bacb3)
+    amqstreams:
+      version: 3.1.0.redhat-00004 (Commit:4c168d2882c7f93d)
+      product_version: 2.1.0
+      rhn_id: 104335
+  3.0.0:
+    scala_version: 2.13
+    upstream:
+      version: 3.0.0 (Commit:8cb0a5e9d3441962)
+    amqstreams:
+      version: 3.0.0.redhat-00008 (Commit:a92f6b92b6cb42fe)
+      product_version: 2.0.1
+      rhn_id: 104108
+  2.8.0:
+    scala_version: 2.12
+    upstream:
+      version: 2.8.0 (Commit:ebb1d6e21cc92130)
+    amqstreams:
+      version: 2.8.0.redhat-00004 (Commit:e4403b1af4b1e4d5)
+      product_version: 1.8.4
+      rhn_id: 103708


### PR DESCRIPTION
The implementation require to define "kafka_amqstreams_version" variable for install AMQ Streams or nothing for install kafka comunity.

## Issue
redhat_csp_download - Red Hat Accounts fail due to SSO change: https://github.com/ansible-middleware/redhat-csp-download/issues/20