### PR TITLE
integrate server configuration generator per oauth and kerberos

### DIFF
--- a/molecule/config/converge.yml
+++ b/molecule/config/converge.yml
@@ -13,20 +13,77 @@
     # Configuration #1 - xxxxx
     - saiello.kafka.kafka_config:
         config:
-          advertise_host: "{{ ansible_host }}"
+          advertised_host: "{{ ansible_host }}"
 
-          tls:
-            trustedCAs:
-              - "{{ certs_source_base }}/ca-root.pem"
+          tls: {}
+            #trustedCA: "{{ certs_source_base }}/ca-root.pem"
+
           listeners:
-            - name: replication
-              port: 9091
-              tls: true
-            - name: admin
+            - name: plain
+              port: 9092
+              tls: false
+            - name: ssl
               port: 9093
               tls: true
-            - name: authenticated
+            - name: sasl_plain_scram-sha-512
               port: 9094
-              tls: true
+              tls: false
+              authentication:
+                type: scram-sha-512
+            - name: sasl_plain_oauthbearer
+              port: 9095
+              tls: false
+              authentication:
+                type: oauthbearer
+                config:
+                  oauth.valid.issuer.uri: "http://AUTH_SERVER/auth/realms/REALM"
+                  oauth.jwks.endpoint.uri: "https://AUTH_SERVER/auth/realms/REALM/protocol/openid-connect/certs"
+                  oauth.username.claim: "preferred_username"
+                  oauth.client.id: "kafka-broker"
+                  oauth.client.secret: "kafka-secret"
+                  oauth.token.endpoint.uri: "https://AUTH-SERVER-ADDRESS/token"
+            - name: sasl_plain_gssapi
+              port: 9096
+              tls: false
+              authentication:
+                type: gssapi
+                config:
+                  useKeyTab: true
+                  storeKey: true
+                  keyTab: "/opt/kafka/krb5/zookeeper-node1.keytab"
+                  principal: "zookeeper/node1.example.redhat.com@EXAMPLE.REDHAT.COM"
+   
+          admin:
+            listener_name: plain
+          
+          authorization: {}
 
-    - debug: var=__kafka_config
+          additional_config: {}
+
+    #- debug: var=__kafka_config
+
+    - name: "Test '{{ item.key }}' authentication method"
+      assert:
+        that:
+          - item.value.sasl is defined
+          - item.value.sasl.gssapi is defined or item.value.sasl.oauthbearer is defined
+        msg: "'JAAS login module' must be configured"
+        quiet: true
+      when:
+         - item.value.authentication is defined
+         - item.value.authentication.type is defined
+         - item.value.authentication.type in ['oauthbearer','gssapi']
+      with_items:
+        - "{{ __kafka_config.listeners | dict2items }}"
+      
+      
+      
+
+     
+
+
+
+
+    
+
+

--- a/roles/kafka_systemd_broker/defaults/main.yml
+++ b/roles/kafka_systemd_broker/defaults/main.yml
@@ -34,12 +34,15 @@ kafka_advertised_host: "{{ ansible_facts[kafka_advertised_interface_name].ipv4.a
 kafka_listeners:
   - name: PLAINTEXT
     port: 9092
-    protocol: PLAINTEXT
+    tls: false
 
 kafka_inter_broker_listener_name: PLAINTEXT
 kafka_admin_listener_name: PLAINTEXT
 
 kafka_jmx_enabled: false
 kafka_jmx_management_port: 9990
+
+kafka_admin:
+  listener_name: PLAINTEXT
 
 kafka_additional_conf: {}

--- a/roles/kafka_systemd_broker/templates/server.properties.j2
+++ b/roles/kafka_systemd_broker/templates/server.properties.j2
@@ -13,35 +13,36 @@ log.dirs={{ kafka_log_dirs | join(',') }}
 zookeeper.connect={{ kafka_zookeeper_connect_servers | join(',') }}
 # TODO allow to configure zookeeper
 
-
 {% for l_name, l_config in __kafka_config.listeners.items() %}
+
 {% if l_config.tls %}
 # ---- {{ l_name }} -----
-listener.name.{{ l_name }}.ssl.truststore.location={{ l_config.truststore_location }}
-listener.name.{{ l_name }}.ssl.truststore.type={{ l_config.truststore_type }}
-listener.name.{{ l_name }}.ssl.keystore.location={{ l_config.keystore_location }}
-listener.name.{{ l_name }}.ssl.keystore.password={{ l_config.keystore_password }}
-listener.name.{{ l_name }}.ssl.keystore.type={{ l_config.keystore_type }}
-{% if 'sasl' in l_config %}
-listener.name.{{ l_name }}.sasl.enabled.mechanisms={{ l_config.sasl.keys() | map('upper') | join(',') }}
-{% for sasl_mechanism, sasl_config in l_config.sasl.items() %}
-listener.name.{{ l_name }}.{{ sasl_mechanism }}.sasl.jaas.config={{ sasl_config }}
-{% endfor %}
-{% endif %}
+listener.name.{{ l_name | lower }}.ssl.truststore.location={{ l_config.truststore_location }}
+listener.name.{{ l_name | lower }}.ssl.truststore.type={{ l_config.truststore_type }}
+listener.name.{{ l_name | lower }}.ssl.keystore.location={{ l_config.keystore_location }}
+listener.name.{{ l_name | lower }}.ssl.keystore.password={{ l_config.keystore_password }}
+listener.name.{{ l_name | lower }}.ssl.keystore.type={{ l_config.keystore_type }}
 {% if 'ssl_client_auth' in l_config %}
-listener.name.{{ l_name }}.ssl.client.auth={{ l_config.ssl_client_auth }}
+listener.name.{{ l_name | lower }}.ssl.client.auth={{ l_config.ssl_client_auth }}
 {% endif %}
+{% endif %}
+{% if 'sasl' in l_config %}
+listener.name.{{ l_name | lower }}.sasl.enabled.mechanisms={{ l_config.sasl.keys() | map('upper') | join(',') }}
+{% for sasl_mechanism, sasl_config in l_config.sasl.items() %}
+listener.name.{{ l_name | lower }}.{{ sasl_mechanism }}.sasl.jaas.config={{ sasl_config | replace('\\n', '\n') }}
+{% if sasl_mechanism in ['gssapi'] %}
+
+sasl.kerberos.service.name=kafka
 {% endif %}
 {% endfor %}
-
-
+{% endif %}
+{% endfor %}
 
 {% if __kafka_config.authorization %}
 allow.everyone.if.no.acl.found = {{ __kafka_config.authorization['allow.everyone.if.no.acl.found'] }}
 authorizer.class.name = {{ __kafka_config.authorization['authorizer.class.name'] }}
 super.users = {{ __kafka_config.authorization['super.users'] | join(';') }}
 {% endif %}
-
 
 {% for kafka_conf_key, kafka_conf_value in __kafka_config.additional_config.items() %}
 {{ kafka_conf_key }}={{ kafka_conf_value }}


### PR DESCRIPTION
Added support for server configuration of the following authentication methods: oauthbearer and gssapi.

Here is an example of how to configure:
````
 - name: sasl_plain_oauthbearer
... omit...
    authentication:
      type: oauthbearer
      config:
        oauth.valid.issuer.uri: "http://AUTH_SERVER/auth/realms/REALM"
        oauth.jwks.endpoint.uri: "https://AUTH_SERVER/auth/realms/REALM/protocol/openid-connect/certs"
... omit...

  - name: sasl_plain_gssapi
... omit...
    authentication:
      type: gssapi
      config:
        useKeyTab: true
        storeKey: true
... omit...
````
